### PR TITLE
Fix regex for comments

### DIFF
--- a/trizen
+++ b/trizen
@@ -566,8 +566,10 @@ sub get_comments ($id) {
             <h4\b.*?>\s*
                 (\S(?-s:.*?))\ commented\ on\ (\d\d\d\d-\d\d-\d\d\ \d\d:\d\d)
          \s*</h4>\s*
-        <div\s+class="article-content">\s*
-            <p>\s*(.*?)\s*</p>\s*
+        <div\b.*?class="article-content">\s*
+            <div>\s*
+                <p>\s*(.*?)\s*</p>\s*
+            </div>\s*
         </div>
         }gsix
       ) {


### PR DESCRIPTION
I just switched over to using trizen after hearing that pacaur is now unmaintained.

I see that trizen has a `-C` option to see aur comments. This sounds really useful to me, but it seems like it's not quite working right now. Here's an example comment from [pacaur](https://aur.archlinux.org/packages/pacaur/)

```html
<!-- Note: I've cleaned up the whitespace a little to make it more readable -->
<h4 id="comment-625316">
  ArchNemo commented on 2017-12-17 18:19
</h4>
<div id="comment-625316-content" class="article-content">
  <div>
    <p>Thank you very much for maintaining this awesome package all this time.</p>          
  </div>
</div>
```

Looks like there's an extra/intermediate `<div>` the current regex isn't handling. Also, doesn't seem like the attribute `id="comment-625316-content"` is taken into account either.

P.S. if you don't like how I did the new regexes, I can fix em. And thanks for maintaining this package 😄 