### PR TITLE
Add configuration `packages_to_be_update_eval`.

### DIFF
--- a/trizen
+++ b/trizen
@@ -140,6 +140,7 @@ my %CONFIG = (
               movepkg_dir                  => '/var/cache/pacman/pkg',
               pacman_local_dir             => '/var/lib/pacman/local',
               pacman_command               => '/usr/bin/pacman',
+              packages_to_be_update_eval   => '/usr/bin/pacman -Qm',
               show_build_files_content     => 1,
               aur_results_sort_by          => 'name',
               aur_results_sort_order       => 'ascending',
@@ -1830,7 +1831,7 @@ sub update_local_packages () {
         return 1;
     }
 
-    my %packages = map { split(' ', $_) } `$lconfig{pacman_command} -Qm`;
+    my %packages = map { split(' ', $_) } `$lconfig{packages_to_be_update_eval}`;
 
     # Get info only for a random subset of 150 packages to avoid the "Request-URI too large" error.
     my @subset = do {


### PR DESCRIPTION
Use it to specify how trizen should know what packages he should check
for updates in the AUR.

It could be useful for users who keep a custom local repository with their aur
packages with a tool like `repoctl` and they want to check for updates in packages
from this repository with setting the configuration option to something like:
```sh
/usr/bin/pacman -Sl custom | sed -e "s/custom //g" -e "s/ \[installed\]$//g"
```

I found it useful after discussing the matter in #34 .