### PR TITLE
Ported Bash completion file from pacaur

### DIFF
--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -42,4 +42,5 @@ package() {
   cd "$_pkgname"
   install -m 755 -D "$_pkgname" "$pkgdir/usr/bin/${_pkgname}"
   install -m 644 -D "zsh.completion" "$pkgdir/usr/share/zsh/site-functions/_trizen"
+  install -m 644 -D "bash.completion" "$pkgdir/usr/share/bash-completion/completions/trizen"
 }

--- a/bash.completion
+++ b/bash.completion
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+#
+# /usr/share/bash-completion/completions/trizen
+#
+
+_aur_pkg() {
+    # at least 2 characters required due to AUR limitation
+    COMPREPLY+=($(compgen -W "$(trizen -Ssaq $cur 2>/dev/null)" -- $cur))
+}
+
+_trizen() {
+    # define variables
+    local cur op o
+    COMPREPLY=()
+    cur=$(_get_cword)
+    if ((COMP_CWORD == 1)); then
+        _pacman &> /dev/null
+        _arch_compgen "${COMPREPLY[@]}" "--version -h --help"
+        return 0
+    fi
+    for o in 'D database' 'F files' 'Q query' 'R remove' 'S sync' 'T deptest' 'U upgrade' 'V version'; do
+        _arch_incomp "$o" && break
+    done
+    (($?)) && op="" || op="${o% *}"
+    _pacman &> /dev/null
+    if [[ "$cur" == -* ]]; then
+        case "$op" in
+            S) _arch_compgen "${COMPREPLY[@]}" "-a --aur --noedit";;
+        esac
+    else
+        case "$op" in
+            S) _pacman_pkg Slq; _aur_pkg;; # No fallback var support.
+            info|buildonly|sync) _aur_pkg;;
+            upgrade|check) _pacman_pkg Qqm;;
+        esac
+    fi
+}
+
+_completion_loader pacman
+complete -o default -F _trizen trizen


### PR DESCRIPTION
This is a pretty straightforward port of the pacaur Bash completion file. Installed, repo and AUR packages are completed just like with pacaur, cower isn't needed. Fixes #59