### PR TITLE
Fix inconsistent text coloring in AUR search results

### DIFF
--- a/trizen
+++ b/trizen
@@ -1750,7 +1750,7 @@ sub print_aur_results (@results) {
           : q{};
 
         # Formatting string
-        my $result_string = "$c{bpurple}aur$c{reset}/$c{bold}%s$c{reset} $c{bblue}%s$c{reset}%s%s%s%s%s%s\n    %s\n";
+        my $result_string = "$c{bpurple}aur/$c{reset}$c{bold}%s$c{reset} $c{bblue}%s$c{reset}%s%s%s%s%s%s\n    %s\n";
 
         # Normalize the popularity percentage
         $result->{Popularity} = sprintf("%.2g", $result->{Popularity});


### PR DESCRIPTION
Fixes a minor inconsistency in the coloring of AUR search results by making the slash separator purple instead of white.

If you look closely at the output of `pacman -Ss <pattern>`, the resulting text shows `core/`, `extra/`, etc. in purple and the package names in white. However, in the AUR search output produced by `trizen`, the resulting text shows only `aur` in purple, and then colors the `/` and the package names in white.

Look closely in the screenshot below for a clear example of what I'm talking about:

![Inconsistent colors screenshot](https://user-images.githubusercontent.com/322831/34919401-63531eee-f931-11e7-9d11-36c8c617dfe3.png)
