### PR TITLE
Only use Term::ReadLine if there's a tty available

### DIFF
--- a/trizen
+++ b/trizen
@@ -649,7 +649,10 @@ require LWP::UserAgent;
 require HTTP::Message;
 
 # Initializing module objects
-my $term = Term::ReadLine->new("$execname $version");
+my $term;
+if ($stdout_on_tty) {
+    $term = Term::ReadLine->new("$execname $version");
+}
 
 my $lwp = LWP::UserAgent->new(
                               env_proxy     => $lconfig{lwp_env_proxy},


### PR DESCRIPTION
Due to a bug, Term::ReadLine creates an empty file named '&STDERR' if
there is no tty available. For more information see:
https://rt.perl.org/Public/Bug/Display.html?id=132008

Only instantiate Term:ReadLine if we know there's a tty available. This
should fix trizen/trizen#55 until the real fix is released upstream.