### PR TITLE
Add option to force color output

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,25 +54,26 @@ usage: trizen [options] [pkgname] [pkgname] [...]
 
 Main options:
 
-    -S, --sync      : install packages (see: trizen -Sh)
-    -C, --comments  : display AUR comments for a package
-    -G, --get       : clones a package in the current directory
-    -R, --remove    : remove packages from the system (see: pacman -Rh)
-    -Q, --query     : query the package database (see: pacman -Qh)
-    -F, --files     : query the files database (see: pacman -Fh)
-    -D, --database  : operate on the package database (see: pacman -Dh)
-    -T, --deptest   : check dependencies (see: pacman -Th)
-    -U, --upgrade   : install built packages from '--clone-dir' or `pwd`
+    -S, --sync         : install packages (see: trizen -Sh)
+    -C, --comments     : display AUR comments for a package
+    -G, --get          : clones a package in the current directory
+    -R, --remove       : remove packages from the system (see: pacman -Rh)
+    -Q, --query        : query the package database (see: pacman -Qh)
+    -F, --files        : query the files database (see: pacman -Fh)
+    -D, --database     : operate on the package database (see: pacman -Dh)
+    -T, --deptest      : check dependencies (see: pacman -Th)
+    -U, --upgrade      : install built packages from '--clone-dir' or `pwd`
 
 Other options:
 
-    -q, --quiet     : do not display any warnings
-    -r, --regular   : use only the regular repositories
-        --stats     : show stats about the installed packages
-        --nocolors  : disable text colors
-        --debug     : activate the debug/verbose mode
-        --help      : print this message and exit
-        --version   : print version and exit
+    -q, --quiet        : do not display any warnings
+    -r, --regular      : use only the regular repositories
+        --stats        : show stats about the installed packages
+        --nocolors     : disable text colors
+        --forcecolors  : force colors when not writing to STDOUT
+        --debug        : activate the debug/verbose mode
+        --help         : print this message and exit
+        --version      : print version and exit
 
 See also:
 

--- a/trizen
+++ b/trizen
@@ -115,9 +115,16 @@ if (not $stdin_on_tty and any { $_ eq '-' } @ARGV) {
 my %args_count;
 ++$args_count{substr($_, 2) =~ tr/-/_/r} for grep { /^--\w/ } @ARGV;
 
-# Disable colors
-if (not $stdout_on_tty or (any { $_ eq '--nocolors' } @ARGV)) {
-    %c = map { ($_ => "") } keys %c;
+my $colors = 2;
+if (not $stdout_on_tty) {
+    $colors = 1;
+}
+if (any { $_ eq '--nocolors' } @ARGV) {
+    $colors = 0;
+}
+
+if (any { $_ eq '--forcecolors' } @ARGV) {
+    $colors = 3;
 }
 
 if (not -d $config_dir) {
@@ -130,6 +137,7 @@ my %CONFIG = (
               show_comments              => 0,
               debug                      => 0,
               nocolors                   => 0,
+              forcecolors                => 0,
               movepkg                    => 0,
               noedit                     => 0,
               noinstall                  => 0,
@@ -260,6 +268,7 @@ makepkg_command              => str     The `makepkg` command that is used inter
 movepkg                      => bool    Move built packages in the directory `movepkg_dir`.
 movepkg_dir                  => str     Absolute path to the directory where to move built packages (with `movepkg`).
 nocolors                     => bool    Disable output colors for `$execname`.
+forcecolors                  => bool    Force output colors for `$execname`.
 noedit                       => bool    Do not prompt to edit files when installing an AUR package.
 noinfo                       => bool    Do not display package information when installing an AUR package.
 noinstall                    => bool    Do not install built packages -- builds only.
@@ -407,13 +416,14 @@ $c{bgreen}Main options:$c{reset}
 
 $c{bgreen}Other options:$c{reset}
 
-    $c{bold}-q$c{reset}, $c{bold}--quiet$c{reset}     : do not display any warnings
-    $c{bold}-r$c{reset}, $c{bold}--regular$c{reset}   : use only the regular repositories
-        $c{bold}--stats$c{reset}     : show stats about the installed packages
-        $c{bold}--nocolors$c{reset}  : disable text colors
-        $c{bold}--debug$c{reset}     : activate the debug/verbose mode
-        $c{bold}--help$c{reset}      : print this message and exit
-        $c{bold}--version$c{reset}   : print version and exit
+    $c{bold}-q$c{reset}, $c{bold}--quiet$c{reset}        : do not display any warnings
+    $c{bold}-r$c{reset}, $c{bold}--regular$c{reset}      : use only the regular repositories
+        $c{bold}--stats$c{reset}        : show stats about the installed packages
+        $c{bold}--nocolors$c{reset}     : disable text colors
+        $c{bold}--forcecolors$c{reset}  : force colors when not writing to STDOUT
+        $c{bold}--debug$c{reset}        : activate the debug/verbose mode
+        $c{bold}--help$c{reset}         : print this message and exit
+        $c{bold}--version$c{reset}      : print version and exit
 
 $c{bgreen}See also:$c{reset}
 
@@ -628,7 +638,17 @@ if ($lconfig{quiet}) {
     $SIG{__WARN__} = sub { };
 }
 
-if ($lconfig{nocolors}) {
+if (($colors == 1) or ($colors == 2)) {
+    if ($lconfig{nocolors}) {
+        $colors = 0;
+    }
+    if ($lconfig{forcecolors}) {
+        $colors = 3;
+    }
+}
+
+# Disable colors respecting parameter > config precedence
+if (($colors == 0) or ($colors == 1)) {
     %c = map { $_ => q{} } keys %c;
 }
 

--- a/trizen.1
+++ b/trizen.1
@@ -81,6 +81,11 @@ Display statistics for the installed packages.
 Disable ANSI colors.
 .RE
 .PP
+\fB\-\-forcecolors\fR
+.RS 4
+Enable colors even when not writing to STDOUT.
+.RE
+.PP
 \fB\-\-debug\fR
 .RS 4
 Enable verbose mode.


### PR DESCRIPTION
The parameter or config option 'forcecolors' forces color output even
when not writing to STDOUT. It takes precedence over 'nocolors'.
Implementing this was a little bit hacky due to the fact that the config
file is evaluated after the commandline parameters.
The $colors variable used can hold the following 4 values:
0 -> force colors off
1 -> colors off because of no STDOUT
2 -> default colors on
3 -> force color on