### PR TITLE
Default to y on sudo retry prompt

### DIFF
--- a/trizen
+++ b/trizen
@@ -909,7 +909,7 @@ sub execute_pacman_command ($needs_root, @cmd) {
             }
 
             note(":: Exit code: " . exit_code()) if $lconfig{debug};
-            $term->ask_yn(prompt => "$c{bold}=>> Try again?$c{reset}", default => 'n') and redo;
+            $term->ask_yn(prompt => "$c{bold}=>> Try again?$c{reset}", default => 'y') and redo;
         }
     }
 


### PR DESCRIPTION
I don't generally watch long builds, so I'll often often miss the sudo password prompt causing it to time out. Having a default of 'y' here makes sense (to me) as I always have to override the default and hit 'y'. Often I hit enter (as I do for all the other defaults) and the program exits without installing the package that was just build so I have to copy paste the command from trizen's output.