### PR TITLE
Add --nocheck option

### DIFF
--- a/TRIZEN.md
+++ b/TRIZEN.md
@@ -109,6 +109,7 @@ Other options:
       --noedit        : do not prompt to edit files
       --nobuild       : do not build packages (implies --noedit)
       --noinstall     : do not install packages after building
+      --nocheck       : do not check() packages or install check dependencies
       --needed        : do not reinstall up-to-date packages
       --asdeps        : install packages as non-explicitly installed
       --asexplicit    : install packages as explicitly installed

--- a/fish.completion
+++ b/fish.completion
@@ -124,6 +124,7 @@ complete -c $progname -n $hasopt      -l noinfo      -d 'Do not display package 
 complete -c $progname -n $hasopt      -l nopull      -d 'Do not pull new changes'
 complete -c $progname -n $hasopt      -l nobuild     -d 'Do not build packages (implies --noedit)'
 complete -c $progname -n $hasopt      -l noinstall   -d 'Do not install packages after building'
+complete -c $progname -n $hasopt      -l nocheck     -d 'Do not check() packages or install check dependencies'
 complete -c $progname -n $hasopt      -l skipinteg   -d 'Pass --skipinteg to makepkg'
 complete -c $progname -n $hasopt      -l movepkg     -d 'Move built packages into pacman\'s cache directory'
 complete -c $progname -n $hasopt      -l movepkg-dir -d 'Move built packages into this directory (implies --movepkg)'

--- a/trizen
+++ b/trizen
@@ -151,6 +151,7 @@ my %CONFIG = (
               nocolors                   => 0,
               forcecolors                => 0,
               movepkg                    => 0,
+              nocheck                    => 0,
               noedit                     => 0,
               noinstall                  => 0,
               nopull                     => 0,
@@ -280,6 +281,7 @@ movepkg                      => bool    Move built packages in the directory `mo
 movepkg_dir                  => str     Absolute path to the directory where to move built packages (with `movepkg`).
 nocolors                     => bool    Disable output colors for `$execname`.
 forcecolors                  => bool    Force output colors even when not writing to STDOUT.
+nocheck                      => bool    Do not run the check() function in the PKGBUILD or install any checkdepends.
 noedit                       => bool    Do not prompt to edit files when installing an AUR package.
 noinfo                       => bool    Do not display package information when installing an AUR package.
 noinstall                    => bool    Do not install built packages -- builds only.
@@ -479,6 +481,7 @@ $c{bgreen}Other options:$c{reset}
       $c{bold}--noedit$c{reset}        : do not prompt to edit files
       $c{bold}--nobuild$c{reset}       : do not build packages (implies --noedit)
       $c{bold}--noinstall$c{reset}     : do not install packages after building
+      $c{bold}--nocheck$c{reset}       : do not check() packages or install checkdepends
       $c{bold}--needed$c{reset}        : do not reinstall up-to-date packages
       $c{bold}--asdeps$c{reset}        : install packages as non-explicitly installed
       $c{bold}--asexplicit$c{reset}    : install packages as explicitly installed
@@ -632,6 +635,10 @@ if ($lconfig{noconfirm}) {
 }
 else {
     $Term::UI::AUTOREPLY = 0;
+}
+
+if ($lconfig{nocheck}) {
+    $lconfig{makepkg_command} .= ' --nocheck';
 }
 
 # `--asdep` as alias for `--asdeps`
@@ -1798,7 +1805,7 @@ sub install_package ($pkg) {
         (exists($info->{MakeDepends}) ? @{$info->{MakeDepends}} : ()),
 
         # CheckDepends
-        (exists($info->{CheckDepends}) ? @{$info->{CheckDepends}} : ()),
+        (!$lconfig{nocheck} and exists($info->{CheckDepends}) ? @{$info->{CheckDepends}} : ()),
 
         # Depends
         (exists($info->{Depends}) ? @{$info->{Depends}} : ()),

--- a/trizen.1
+++ b/trizen.1
@@ -172,6 +172,11 @@ Do not build packages (implies \fI--noedit\fR). Assumes a built package already 
 Do not install packages after building.
 .RE
 .PP
+\fB\-\-nocheck\fR
+.RS 4
+Do not check() packages or install check dependencies.
+.RE
+.PP
 \fB\-\-noconfirm\fR
 .RS 4
 Do not ask for any confirmation.

--- a/zsh.completion
+++ b/zsh.completion
@@ -141,6 +141,7 @@ _trizen_opts_sync_modifiers=(
     '--ignore[Space-separated list of packages to ignore]'
     '--nobuild[Do not build packages (implies --noedit)]'
     '--noinstall[Do not install packages after building]'
+    '--nocheck[Do not check() packages or install check dependencies]'
     '--skipinteg[Pass the `--skipinteg` argument to `makepkg`]'
 )
 


### PR DESCRIPTION
This patch allows the user to enable a new `--nocheck` option when running trizen if they do not want to install the check dependencies or run the PKGBUILD script's `check()` function. Enabling this option will skip installation of checkdepends by the trizen program, and pass the [--nocheck option](https://man.archlinux.org/man/makepkg.8.en) to `makepkg` so that it doesn't try to run the `check()` step.

This new option is disabled by default because that matches the current default behavior. But it can be enabled by default if the user sets the value of the `nocheck` option in the trizen.conf file to `1`.

### Reason for the change

Sometimes the check dependencies and PKGBUILD `check()` step causes me frustration. Primarily for post-install cleanup, or being blocked by inconsequential test failures. But also because it causes me review fatigue.

1. **Post-install cleanup**
   When cleaning up after package installation I often have to do explicit uninstalls of checkdepends. I find that the AUR packages for the CPAN ecosystem are a good example of this. Many packages are lovingly maintained with well-meaning `check()` steps. But the dependencies for the tests often have layers of nested dependencies, and each layer has checkdepends, which themselves have layers of dependencies. For example, if I try to install the [perl-finance-quote](https://aur.archlinux.org/packages/perl-finance-quote) package, then it will need to install 55 dependency packages - nearly half of which are check dependencies or dependencies of check dependencies.

   Cleaning up after an install/upgrade of a package like this can be a real chore. Check dependencies are sometimes marked as optional dependencies for other packages. So a naïve uninstall of orphan packages will often miss packages that I have no use for and did not wish to install. To make sure everything gets cleaned up, I have to manually note every package that is installed along the way and pass all of them to `pacman -Rns`. Or manually diff the `pacman -Qtdq` output with the packages that I noted to find anything that wasn't considered an orphan.

2. **Inconsequential test failures**
   Another -fairly uncommon, but annoying- frustration I have is test failures that should not be blocking installation. I've been using the AUR for many years, and I can only recall one time an AUR package's `check()` found a real problem for me (package maintainer forgetting a dependency). However I have been blocked by inconsequential failing tests many times. I have even once caused this problem for others by publishing a package with a `check()` function and forgetting to set the locale in the test suite - causing an assertion failure that didn't apply to any of my computers and didn't affect the actual program being installed.

   In my humble opinion, the `check()` step (which is usually just `make check`) is something primarily meant for developers and packagers. For end users it is often just something to go wrong for reasons that are unrelated to package functionality.

3. **Review fatigue**
   Finally, I generally try to do my due diligence of reviewing the PKGBUILD scripts and related assets to make sure that they are what I would expect. But I find myself succumbing to some kind of verification fatigue when I have to review a lot of packages that I didn't plan to install. When I'm faced with 50 AUR package installs I just can't be bothered to spend the time reviewing/understanding/verifying them, and end up just blindly `Y`-ing my way through the process to get the install over with.

   This may very well just be my own personal failing, but it is not a good practice to encourage. For someone as lazy as me, it is probably better to offer an option to reduce the number of packages needing review. It reduces the security considerations by lowering the amount of code being executed on install, and might serve to limit the possible scope of any supply chain attacks targeting dependencies.

So giving the user the option to skip the `check()` process entirely is a useful feature - at least for me.

Personally, I think that there is a sound argument to be made for having `--nocheck` be the default behavior of an AUR helper. But I didn't want to try to change the default behavior of this program without some discussion. There may be some good reasons to `check()` all packages by default which I haven't considered.

### Testing
 * I have been using this patched version of trizen on my machine for a few weeks now. In that time I have done multiple package upgrades - with and without `--nocheck`. Including packages with nested checkdepends - like perl-finance-quote.
 * I have run a few fresh installs of various packages - with and without `--nocheck`.
 * The fish completions are completely untested. I've never used fish and know very little about it. For the sake of completeness I copy/pasted what looks like a working command. If you like I can dig into it more and try to test it. Or I can remove that bit from my branch if you don't want it.
 * I did test the zsh completions - zsh v5.9.
 * The man page was tested with `man -l trizen.1` - man v2.13.1.

So far I haven't found any issues. But there are a lot of code paths in this program. So I certainly have not exercised all of them.